### PR TITLE
Fix silly typo involing an extra "

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ then
   esac
 
   case "$prefix" in
-    '"'*) prefix="${prefix#*"}" ;;
+    '"'*) prefix="${prefix#*}" ;;
   esac
 
   case "$prefix" in


### PR DESCRIPTION
Your install.sh didn't work, after poking around, I fixed it.
